### PR TITLE
Use maintainerKeySeed bs58 string in all cases, no more path to key file.

### DIFF
--- a/App.js
+++ b/App.js
@@ -21,14 +21,14 @@ const {
  * @param {boolean} options.rejectUnauthorized - Should the httpsAgent reject
  *   invalid SSL certificates?
  * @param {string} options.veresMode - The mode for the veres one driver.
- * @param {string} [options.maintainerKeyWord = 'password'] - A secret for the
- *   maintainer key.
+ * @param {string} options.maintainerKeySeed - A bs58 encoded maintainer key
+ *   seed.
  */
 class App {
   constructor({
     primary, secondary, didMethod,
     keepAlive, rejectUnauthorized,
-    veresMode, maintainerKeyWord, maximumWitnessCount
+    veresMode, maintainerKeySeed, maximumWitnessCount
   }) {
     this.primary = primary;
     this.secondary = secondary;
@@ -36,7 +36,7 @@ class App {
     this.rejectUnauthorized = rejectUnauthorized;
     this.veresMode = veresMode;
     this.didMethod = didMethod;
-    this.maintainerKeyWord = maintainerKeyWord;
+    this.maintainerKeySeed = maintainerKeySeed;
     this.httpsAgent = new https.Agent({
       keepAlive,
       rejectUnauthorized
@@ -161,7 +161,7 @@ class App {
   async create() {
     const {
       httpsAgent,
-      maintainerKeyWord,
+      maintainerKeySeed,
       veresMode,
       didMethod,
       maximumWitnessCount,
@@ -170,7 +170,7 @@ class App {
     } = this;
     // get the maintainer key or generate a new one
     const {didDocument, methodFor} = await getKey({
-      maintainerKeyWord,
+      maintainerKeySeed,
       httpsAgent,
       didMethod,
       veresMode,
@@ -202,7 +202,7 @@ class App {
   async update({existingWitnessPool, meta}) {
     const {
       httpsAgent,
-      maintainerKeyWord,
+      maintainerKeySeed,
       veresMode,
       didMethod,
       maximumWitnessCount,
@@ -211,7 +211,7 @@ class App {
     } = this;
     // get the maintainer key or generate a new one
     const {methodFor} = await getKey({
-      maintainerKeyWord,
+      maintainerKeySeed,
       httpsAgent,
       didMethod,
       veresMode,

--- a/App.js
+++ b/App.js
@@ -21,14 +21,14 @@ const {
  * @param {boolean} options.rejectUnauthorized - Should the httpsAgent reject
  *   invalid SSL certificates?
  * @param {string} options.veresMode - The mode for the veres one driver.
- * @param {string} [options.maintainerKey] - A path to a key file for the
- *   primary node.
+ * @param {string} [options.maintainerKeyWord = 'password'] - A secret for the
+ *   maintainer key.
  */
 class App {
   constructor({
     primary, secondary, didMethod,
     keepAlive, rejectUnauthorized,
-    veresMode, maintainerKey, maximumWitnessCount
+    veresMode, maintainerKeyWord, maximumWitnessCount
   }) {
     this.primary = primary;
     this.secondary = secondary;
@@ -36,7 +36,7 @@ class App {
     this.rejectUnauthorized = rejectUnauthorized;
     this.veresMode = veresMode;
     this.didMethod = didMethod;
-    this.maintainerKey = maintainerKey;
+    this.maintainerKeyWord = maintainerKeyWord;
     this.httpsAgent = new https.Agent({
       keepAlive,
       rejectUnauthorized
@@ -161,7 +161,7 @@ class App {
   async create() {
     const {
       httpsAgent,
-      maintainerKey,
+      maintainerKeyWord,
       veresMode,
       didMethod,
       maximumWitnessCount,
@@ -170,7 +170,7 @@ class App {
     } = this;
     // get the maintainer key or generate a new one
     const {didDocument, methodFor} = await getKey({
-      maintainerKey,
+      maintainerKeyWord,
       httpsAgent,
       didMethod,
       veresMode,
@@ -202,7 +202,7 @@ class App {
   async update({existingWitnessPool, meta}) {
     const {
       httpsAgent,
-      maintainerKey,
+      maintainerKeyWord,
       veresMode,
       didMethod,
       maximumWitnessCount,
@@ -211,7 +211,7 @@ class App {
     } = this;
     // get the maintainer key or generate a new one
     const {methodFor} = await getKey({
-      maintainerKey,
+      maintainerKeyWord,
       httpsAgent,
       didMethod,
       veresMode,

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Options:
                                                                    [default: ""]
   -s, --secondary            A comma separated list of secondary nodes
                                                                    [default: ""]
-  -k, --maintainerKeyWord    A maintainer secret           [default: "password"]
+  -k, --maintainerKeySeed    A bs58 encoded maintainer key seed
   -a, --keepAlive            Whether to keep the httpsAgent agent alive
                                                                  [default: true]
   -r, --rejectUnauthorized   Whether to reject domains with invalid SSL
@@ -53,24 +53,24 @@ This example assumes you have 4 primary nodes.
 The maitainerKeyWord secret is a just string used to recreate the maintainer key for the ledger.
 This will create a witness pool with a fault tolerance of 1.
 ```
-./bin create --primary myNode1.com,myNode2.com,myNode3.com,myNode4.com --maximumWitnessCount 4 --didMethod key --maintainerKeyWord maintainer-key-secret
+./bin create --primary myNode1.com,myNode2.com,myNode3.com,myNode4.com --maximumWitnessCount 4 --didMethod key --maintainerKeySeed zMaintainerKeySeed
 ```
 
 For a `veres-one` ledger node:
 ```
-./bin create --primary myNode1.com,myNode2.com,myNode3.com,myNode4.com --maximumWitnessCount 4 --didMethod v1 --maintainerKeyWord maintainer-key-secret
+./bin create --primary myNode1.com,myNode2.com,myNode3.com,myNode4.com --maximumWitnessCount 4 --didMethod v1 --maintainerKeySeed zMaintainerKeySeed
 ```
 ### Update a Witness Pool Record
 
 These update examples use the cli aliases instead of the full option. Example `--primary` becomes `-p`.
 Additionally, we now have 7 nodes, so we can safely have one secondary node.
 ```
-./bin update -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode5.com,myNode6.com --secondary myNode7.com -w 6 -d key -k maintainer-key-secret
+./bin update -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode5.com,myNode6.com --secondary myNode7.com -w 6 -d key -k zMaintainerKeySeed
 ```
 
 For a `veres-one` ledger node:
 ```
-./bin update -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode5.com,myNode6.com -s myNode7.com -w 6 -d v1 -k maintainer-key-secret
+./bin update -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode5.com,myNode6.com -s myNode7.com -w 6 -d v1 -k zMaintainerKeySeed
 ```
 
 ### Send a Witness Pool Record
@@ -80,12 +80,12 @@ If non exists it calls on create.
 If a record already exists it will issue an update.
 
 ```
-./bin send -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode7.com,myNode6.com -s myNode5.com -w 6 -d key -k maintainer-key-secret
+./bin send -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode7.com,myNode6.com -s myNode5.com -w 6 -d key -k zMaintainerKeySeed
 ```
 
 For a `veres-one` ledger node:
 ```
-./bin send -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode7.com,myNode6.com -s myNode5.com -w 6 -d v1 -k maintainer-key-secret
+./bin send -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode7.com,myNode6.com -s myNode5.com -w 6 -d v1 -k zMaintainerKeySeed
 ```
 
 ### Fault Tolerance

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Options:
                                                                    [default: ""]
   -s, --secondary            A comma separated list of secondary nodes
                                                                    [default: ""]
-  -k, --maintainerKey        A maintainer secret or a file containing material
-                             for a v1 key                  [default: "password"]
+  -k, --maintainerKeyWord    A maintainer secret           [default: "password"]
   -a, --keepAlive            Whether to keep the httpsAgent agent alive
                                                                  [default: true]
   -r, --rejectUnauthorized   Whether to reject domains with invalid SSL
@@ -51,15 +50,15 @@ Options:
 
 This example is for a non-veres-one ledger that uses did keys.
 This example assumes you have 4 primary nodes.
-The maintainerKey secret is a just string used to recreate the maintainer key for the ledger.
+The maitainerKeyWord secret is a just string used to recreate the maintainer key for the ledger.
 This will create a witness pool with a fault tolerance of 1.
 ```
-./bin create --primary myNode1.com,myNode2.com,myNode3.com,myNode4.com --maximumWitnessCount 4 --didMethod key --maintainerKey maintainer-key-secret
+./bin create --primary myNode1.com,myNode2.com,myNode3.com,myNode4.com --maximumWitnessCount 4 --didMethod key --maintainerKeyWord maintainer-key-secret
 ```
 
 For a `veres-one` ledger node:
 ```
-./bin create --primary myNode1.com,myNode2.com,myNode3.com,myNode4.com --maximumWitnessCount 4 --didMethod v1 --maintainerKey path/to/maintainerKey.json
+./bin create --primary myNode1.com,myNode2.com,myNode3.com,myNode4.com --maximumWitnessCount 4 --didMethod v1 --maintainerKeyWord maintainer-key-secret
 ```
 ### Update a Witness Pool Record
 
@@ -71,7 +70,7 @@ Additionally, we now have 7 nodes, so we can safely have one secondary node.
 
 For a `veres-one` ledger node:
 ```
-./bin update -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode5.com,myNode6.com -s myNode7.com -w 6 -d v1 -k path/to/maintainerKey.json
+./bin update -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode5.com,myNode6.com -s myNode7.com -w 6 -d v1 -k maintainer-key-secret
 ```
 
 ### Send a Witness Pool Record
@@ -86,7 +85,7 @@ If a record already exists it will issue an update.
 
 For a `veres-one` ledger node:
 ```
-./bin send -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode7.com,myNode6.com -s myNode5.com -w 6 -d v1 -k path/to/maintainerKey.json
+./bin send -p myNode1.com,myNode2.com,myNode3.com,myNode4.com,myNode7.com,myNode6.com -s myNode5.com -w 6 -d v1 -k maintainer-key-secret
 ```
 
 ### Fault Tolerance
@@ -111,16 +110,3 @@ const twoFaultsPrimaryNodes = minPrimaryNodes(2);
 // so for two faults you need 7 nodes with 6 of those nodes being primary
 // the seventh node can be primary or secondary
 ```
-
-### Maintainer Key format
-Veres One ledgers require the maintainer key is a piece of json in this format:
-
-```js
-{
-  "type": "Ed25519VerificationKey2020",
-  "publicKeyMultibase": "zpublicKeyMultibase",
-  "privateKeyMultibase": "zprivateKeyMultibase"
-}
-```
-
-You can get this by [exporting an Ed25519VerificationKey2020 to a file](https://github.com/digitalbazaar/ed25519-verification-key-2020).

--- a/bin
+++ b/bin
@@ -26,10 +26,9 @@ function _setupCLIOptions() {
       alias: 's',
       describe: 'A comma separated list of secondary nodes',
       default: ''
-    }).option('maintainerKey', {
+    }).option('maintainerKeyWord', {
       alias: 'k',
-      describe: 'A maintainer secret or a file containing ' +
-        'material for a v1 key',
+      describe: 'A maintainer secret',
       default: 'password'
     }).option('keepAlive', {
       alias: 'a',

--- a/bin
+++ b/bin
@@ -26,10 +26,9 @@ function _setupCLIOptions() {
       alias: 's',
       describe: 'A comma separated list of secondary nodes',
       default: ''
-    }).option('maintainerKeyWord', {
+    }).option('maintainerKeySeed', {
       alias: 'k',
-      describe: 'A maintainer secret',
-      default: 'password'
+      describe: 'A bs58 encoded maintainer key seed',
     }).option('keepAlive', {
       alias: 'a',
       describe: 'Whether to keep the httpsAgent agent alive',

--- a/helpers.js
+++ b/helpers.js
@@ -3,7 +3,6 @@
  *  Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
 */
 
-const crypto = require('crypto');
 const {WebLedgerClient} = require('web-ledger-client');
 const v1 = require('did-veres-one');
 const didKeyDriver = require('@digitalbazaar/did-method-key').driver();
@@ -99,6 +98,9 @@ async function getKey({
   httpsAgent,
   hostname
 }) {
+  if(typeof maintainerKeySeed !== 'string') {
+    throw new Error('Expected maintainerKeySeed to be a bs58 encoded string.');
+  }
   const seed = decodeSecretKeySeed({secretKeySeed: maintainerKeySeed});
   switch(didMethod.toLowerCase()) {
     case 'v1': {

--- a/operations.js
+++ b/operations.js
@@ -102,7 +102,6 @@ api.signOperation = async ({
         operation: opWithLedgerProof,
         capability: `urn:zcap:root:${encodeURIComponent(witnessPoolId)}`,
         capabilityAction: 'write',
-        invocationTarget: witnessPoolId,
         key,
         signer: key.signer()
       });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@digitalbazaar/ed25519-signature-2020": "^3.0.0",
     "@digitalbazaar/zcapld": "^5.2.0",
     "@digitalcredentials/did-context": "^1.0.0",
+    "bnid": "^2.1.0",
     "chalk": "^4.1.2",
     "did-veres-one": "github:veres-one/did-veres-one#v14.x",
     "ed25519-signature-2020-context": "^1.1.0",


### PR DESCRIPTION
Uses the new `generate({seed})` feature in `did-veres-one: v14.x` so that the maintainerKey is always created from a bs58 encoded string instead of an exported ed25519 keypair. Previously `did-method-key-js` took a `seed` while `did-veres-one` required an `invokeKey` created from a json file.

If you need to test a bs58 encoded string use:

```js
const bnid = require('bnid');
bnid.,generateSecretKeySeed().then(console.log)
```

Then just pass the result to the CLI via `-k`